### PR TITLE
Implement TreeFellEvent

### DIFF
--- a/Asphalt-ModKit/Events/EventManagerHelper.cs
+++ b/Asphalt-ModKit/Events/EventManagerHelper.cs
@@ -117,8 +117,7 @@ namespace Asphalt.Events
                     Injection.InstallWithOriginalHelperPublicStatic(typeof(EcoObjectManager), typeof(RubbleSpawnEventHelper), "Add");
                     break;
                 case nameof(TreeFellEvent):
-                    //TODO
-                    //Injection.InstallWithOriginalHelperPublicInstance(typeof(TreeEntity), typeof(TreeFellEventHelper), "FellTree");
+                    Injection.InstallWithOriginalHelperNonPublicInstance(typeof(TreeEntity), typeof(TreeFellEventHelper), "FellTree");
                     break;
 
                 case nameof(WorldObjectChangeTextEvent):


### PR DESCRIPTION
`TreeEntity.FellTree()` is private, so `InstallWithOriginalHelperNonPublicInstance` is used. In my testing this event fires reliably and can be cancelled. If cancelled, the tree outline changes from green to yellow in the client, but the tree does not fall over, is not harvestable, and if you log out and back in the tree outline is green again. Please let me know if there are other things that you wanted handled as part of the "TODO" comment.