### PR TITLE
Add WorldObjectPickupEvent

### DIFF
--- a/Asphalt-ModKit/Asphalt-ModKit.csproj
+++ b/Asphalt-ModKit/Asphalt-ModKit.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Events\WorldObjectEvent\WorldObjectEnabledChangedEvent.cs" />
     <Compile Include="Events\WorldObjectEvent\WorldObjectNameChangedEvent.cs" />
     <Compile Include="Events\WorldObjectEvent\WorldObjectOperatingChangedEvent.cs" />
+    <Compile Include="Events\WorldObjectEvent\WorldObjectPickupEvent.cs" />
     <Compile Include="InjectAttribute.cs" />
     <Compile Include="Service\IDisableable.cs" />
     <Compile Include="Service\IReloadable.cs" />

--- a/Asphalt-ModKit/Events/EventManagerHelper.cs
+++ b/Asphalt-ModKit/Events/EventManagerHelper.cs
@@ -135,6 +135,9 @@ namespace Asphalt.Events
                 case nameof(WorldObjectOperatingChangedEvent):
                     Injection.InstallWithOriginalHelperNonPublicInstance(typeof(WorldObject), typeof(WorldObjectOperatingChangedEventHelper), "set_Operating");
                     break;
+                case nameof(WorldObjectPickupEvent):
+                    Injection.InstallWithOriginalHelperPublicInstance(typeof(WorldObject), typeof(WorldObjectPickupEventHelper), "TryPickUp");
+                    break;
             }
         }
     }

--- a/Asphalt-ModKit/Events/WorldObjectEvent/WorldObjectPickupEvent.cs
+++ b/Asphalt-ModKit/Events/WorldObjectEvent/WorldObjectPickupEvent.cs
@@ -1,0 +1,39 @@
+﻿using Asphalt.Api.Event;
+using Eco.Core.Utils.AtomicAction;
+using Eco.Gameplay.Objects;
+using Eco.Gameplay.Players;
+using Eco.Shared.Localization;
+
+namespace Asphalt.Events.WorldObjectEvent
+{
+    public class WorldObjectPickupEvent : CancellableEvent
+    {
+        public WorldObject WorldObject { get; set; }
+        public Player Picker { get; set; }
+
+        public WorldObjectPickupEvent(ref WorldObject worldObject, ref Player picker) : base()
+        {
+            WorldObject = worldObject;
+            Picker = picker;
+        }
+    }
+
+    internal class WorldObjectPickupEventHelper
+    {
+        public static bool Prefix(ref Player player, ref WorldObject __instance, ref IAtomicAction __result)
+        {
+            var wope = new WorldObjectPickupEvent(ref __instance, ref player);
+            var wopeEvent = (IEvent)wope;
+
+            EventManager.CallEvent(ref wopeEvent);
+
+            if (wope.IsCancelled())
+            {
+                __result = new FailedAtomicAction(new LocString("Asphalt " + nameof(WorldObjectPickupEvent)));
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Currently, only the Hammer calls the patched method when trying to pick up a world object, but theoretically this is extensible if other methods of pickup are added.